### PR TITLE
fix #28 with a new request state

### DIFF
--- a/data-rights-protocol.md
+++ b/data-rights-protocol.md
@@ -189,10 +189,11 @@ This table shows valid states for Data Rights Requests, along with the criteria 
 | denied      | no_match               | CB could not match user identity to data subject                    |                                   | x      |
 | denied      | claim_not_covered      | user requesting data not covered under legal bases[XXX]             |                                   | x      |
 | denied      | outside_jurisdiction   | user requesting data under bases they are not covered by[XXX]       |                                   | x      |
+| denied      | too_many_requests      | user has submitted more requests than the CB is legally obliged to process | details?
 | denied      | other                  | some other unspecified failure state reached                        | details?                          | x      |
 | expired     |                        | the time is currently after the `expires_at` in the request.        |                                   | x      |
 
-[XXX] in the case of claim_not_covered, this may be about asking for categories of data which Covered Businesses are not required to present to the User. in the case of outside_jurisdiction, this may be because the business is not honoring CCPA requests for non-California residents and there is no other basis on which to honor the request.
+[XXX] in the case of claim_not_covered, this may be about asking for categories of data which Covered Businesses are not required to present to the User. in the case of outside_jurisdiction, this may be because the business is not honoring CCPA requests for non-California residents and there is no other basis on which to honor the request. [#28](https://github.com/consumer-reports-digital-lab/data-rights-protocol/issues/28) for discussion on `too_many_requests`
 
 #### 3.02.1: `need_user_verification` State Flow Semantics
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,251 @@
+# [[file:../../org/data_rights_interface_protocol.org::*Tangle][Tangle:1]]
+openapi: 3.0.0
+info:
+  version: 0.4
+  title: Data Rights Protocol - PIP Interface
+
+components:
+  schemas:
+    JSONWebToken:
+      oneOf:
+        # - $ref: "#/components/schemas/JSONSerializedJWT"
+        - $ref: "#/components/schemas/FlattenedJSONSerializedJWT"
+        - $ref: "#/components/schemas/StringSerializedJWT"
+    
+    JWTClaims:
+      type: object
+      format: base64
+      required:
+        - iss
+        - aud
+      properties:
+        iss:
+          type: string
+        aud:
+          type: string
+        sub:
+          type: string
+        # user claims
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        email_verified:
+          type: string
+          format: email
+        phone_number:
+          type: string
+        phone_number_verified:
+          type: string
+        address:
+          type: string
+        address_verified:
+          type: string
+        power_of_attorney:
+          type: string
+    
+    StringSerializedJWT:
+      type: byte
+      format: base64
+      description: JWS Compact Serialization JWT -  https://datatracker.ietf.org/doc/html/rfc7515#section-7.1
+    
+    # https://github.com/OAI/OpenAPI-Specification/issues/1971
+    FlattenedJSONSerializedJWT:
+      type: object
+      description: JWS Flattened JSON Serialized JWT - https://datatracker.ietf.org/doc/html/rfc7515#section-7.2
+      properties:
+        payload:
+          $ref: "#/components/schemas/JWTClaims"
+        signatures:
+          type: array
+          items:
+            type: object
+        protected:
+          type: string
+        header:
+          type: object            
+    DataRightsRequest:
+      type: object
+      required:
+        - meta
+        - regime
+        - exercise
+        - identity
+      properties:
+        meta:
+          type: object
+          required:
+          - version
+          properties:
+            version:
+              type: string
+              description: the version of the DRP API as implemented. 
+              example: "0.4"
+              enum: [ 0.4 ]
+        regime:
+          type: string
+          example: ccpa
+          enum: [ ccpa ]
+        exercise:
+          type: array
+          items:
+            type: string
+          enum: 
+            - "sale:opt-out"
+            - "sale:opt-in"
+            - "deletion"
+            - "access"
+            - "access:categories"
+            - "access:specific"
+        identity:
+          oneOf:
+            - $ref: '#/components/schemas/JSONWebToken'
+        relationships:
+          type: array
+          items:
+            type: string
+        # https://swagger.io/docs/specification/callbacks/
+        status_callback:
+          type: string
+          format: uri
+    DataRightsStatus:
+      type: object
+      required:
+      - request_id
+      - received_at
+      - status
+      properties:
+        request_id:
+          type: string
+          format: uuid
+        received_at:
+          type: date-time
+        results_url:
+          type: string
+          format: uri
+        # how to express how these compose together?
+        status:
+          type: string
+          enum:
+          - in_progress
+          - open
+          - fulfilled
+          - revoked
+          - denied
+          - expired
+        reason:
+          type: string
+          enum:
+          - need_user_verification
+          - suspected_fraud
+          - insuf_verification
+          - no_match
+          - claim_not_covered
+          - too_many_requests
+          - other
+
+  responses:
+    ValidDRRStatus:
+      description: The Data Rights Request was captured by the PIP.
+      content:
+        application/json:
+          schema: 
+            $ref: '#/components/schemas/DataRightsStatus'
+      links:
+        GetDRRStatus:
+          operationId: exerciseStatus
+          description: Status's requestId can be used to get the status again.
+          parameters:
+            requestId: '$response.body#/request_id'
+        RevokeDRR:
+          operationId: revokeRequest
+          description: Status's requestId can be used to revoke open DRRs
+          parameters:
+            requestId: '$response.body#/request_id'
+    
+    InvalidDRRStatus:
+      description: The submitted or queried Data Rights Request is in an invalid state
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - code
+              - message
+            properties:
+              code:
+                description: This must be the same as the HTTP status code for clients which cannot process the headers.
+                type: string
+              message:
+                type: string
+              fatal:
+                type: boolean
+
+paths:
+  /exercise:
+    post:
+      summary: Submit a new Data Rights Request
+      operationId: exerciseRequest
+      requestBody: 
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataRightsRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/ValidDRRStatus'
+        '4XX':
+          $ref: '#/components/responses/InvalidDRRStatus'
+        '5XX':
+          $ref: '#/components/responses/InvalidDRRStatus'
+
+  /status:
+    get:
+      summary: Query the PIP interface for the status of an existing request
+      operationId: exerciseStatus
+      parameters:
+        - in: query
+          name: requestId
+          schema:
+            type: string
+            format: uuid
+          required: true
+          description: the Request ID returned in exerciseRequest
+      responses:
+        '200':
+          $ref: '#/components/responses/ValidDRRStatus'
+        '4XX':
+          $ref: '#/components/responses/InvalidDRRStatus'
+        '5XX':
+          $ref: '#/components/responses/InvalidDRRStatus'
+
+  /revoke:
+    post:
+      summary: Cancel or revoke an in-progress Data Rights Request
+      description: >-
+        This endpoint will instruct the PIP to cancel or revoke a Data
+        Rights Request which is still in a non-terminal state.
+      operationId: revokeRequest
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - request_id
+              properties:
+                request_id:
+                  description: The ID of the request to revoke
+                  type: string
+                  format: uuid
+                reason:
+                  description: MAY contain a user-provided reason for the request to not be processed
+                  type: string
+            
+      responses:
+        '200':
+          $ref: '#/components/responses/ValidDRRStatus'
+# Tangle:1 ends here


### PR DESCRIPTION
This is not fully enumerative, and its usecases need to be defined but
this gives us a good basis to encode these unaccounted-for failure states (see #28 )

cc @ginnyfahs this is a request failure state which wasn't represented in the flows you worked out with PS.