### PR TITLE
the start of a openapi spec for PIPs

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,251 @@
+# [[file:../../org/data_rights_interface_protocol.org::*Tangle][Tangle:1]]
+openapi: 3.0.0
+info:
+  version: 0.4
+  title: Data Rights Protocol - PIP Interface
+
+components:
+  schemas:
+    JSONWebToken:
+      oneOf:
+        # - $ref: "#/components/schemas/JSONSerializedJWT"
+        - $ref: "#/components/schemas/FlattenedJSONSerializedJWT"
+        - $ref: "#/components/schemas/StringSerializedJWT"
+    
+    JWTClaims:
+      type: object
+      format: base64
+      required:
+        - iss
+        - aud
+      properties:
+        iss:
+          type: string
+        aud:
+          type: string
+        sub:
+          type: string
+        # user claims
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        email_verified:
+          type: string
+          format: email
+        phone_number:
+          type: string
+        phone_number_verified:
+          type: string
+        address:
+          type: string
+        address_verified:
+          type: string
+        power_of_attorney:
+          type: string
+    
+    StringSerializedJWT:
+      type: byte
+      format: base64
+      description: JWS Compact Serialization JWT -  https://datatracker.ietf.org/doc/html/rfc7515#section-7.1
+    
+    # https://github.com/OAI/OpenAPI-Specification/issues/1971
+    FlattenedJSONSerializedJWT:
+      type: object
+      description: JWS Flattened JSON Serialized JWT - https://datatracker.ietf.org/doc/html/rfc7515#section-7.2
+      properties:
+        payload:
+          $ref: "#/components/schemas/JWTClaims"
+        signatures:
+          type: array
+          items:
+            type: object
+        protected:
+          type: string
+        header:
+          type: object            
+    DataRightsRequest:
+      type: object
+      required:
+        - meta
+        - regime
+        - exercise
+        - identity
+      properties:
+        meta:
+          type: object
+          required:
+          - version
+          properties:
+            version:
+              type: string
+              description: the version of the DRP API as implemented. 
+              example: "0.4"
+              enum: [ 0.4 ]
+        regime:
+          type: string
+          example: ccpa
+          enum: [ ccpa ]
+        exercise:
+          type: array
+          items:
+            type: string
+          enum: 
+            - "sale:opt-out"
+            - "sale:opt-in"
+            - "deletion"
+            - "access"
+            - "access:categories"
+            - "access:specific"
+        identity:
+          oneOf:
+            - $ref: '#/components/schemas/JSONWebToken'
+        relationships:
+          type: array
+          items:
+            type: string
+        # https://swagger.io/docs/specification/callbacks/
+        status_callback:
+          type: string
+          format: uri
+    DataRightsStatus:
+      type: object
+      required:
+      - request_id
+      - received_at
+      - status
+      properties:
+        request_id:
+          type: string
+          format: uuid
+        received_at:
+          type: date-time
+        results_url:
+          type: string
+          format: uri
+        # how to express how these compose together?
+        status:
+          type: string
+          enum:
+          - in_progress
+          - open
+          - fulfilled
+          - revoked
+          - denied
+          - expired
+        reason:
+          type: string
+          enum:
+          - need_user_verification
+          - suspected_fraud
+          - insuf_verification
+          - no_match
+          - claim_not_covered
+          - too_many_requests
+          - other
+
+  responses:
+    ValidDRRStatus:
+      description: The Data Rights Request was captured by the PIP.
+      content:
+        application/json:
+          schema: 
+            $ref: '#/components/schemas/DataRightsStatus'
+      links:
+        GetDRRStatus:
+          operationId: exerciseStatus
+          description: Status's requestId can be used to get the status again.
+          parameters:
+            requestId: '$response.body#/request_id'
+        RevokeDRR:
+          operationId: revokeRequest
+          description: Status's requestId can be used to revoke open DRRs
+          parameters:
+            requestId: '$response.body#/request_id'
+    
+    InvalidDRRStatus:
+      description: The submitted or queried Data Rights Request is in an invalid state
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - code
+              - message
+            properties:
+              code:
+                description: This must be the same as the HTTP status code for clients which cannot process the headers.
+                type: string
+              message:
+                type: string
+              fatal:
+                type: boolean
+
+paths:
+  /exercise:
+    post:
+      summary: Submit a new Data Rights Request
+      operationId: exerciseRequest
+      requestBody: 
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataRightsRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/ValidDRRStatus'
+        '4XX':
+          $ref: '#/components/responses/InvalidDRRStatus'
+        '5XX':
+          $ref: '#/components/responses/InvalidDRRStatus'
+
+  /status:
+    get:
+      summary: Query the PIP interface for the status of an existing request
+      operationId: exerciseStatus
+      parameters:
+        - in: query
+          name: requestId
+          schema:
+            type: string
+            format: uuid
+          required: true
+          description: the Request ID returned in exerciseRequest
+      responses:
+        '200':
+          $ref: '#/components/responses/ValidDRRStatus'
+        '4XX':
+          $ref: '#/components/responses/InvalidDRRStatus'
+        '5XX':
+          $ref: '#/components/responses/InvalidDRRStatus'
+
+  /revoke:
+    post:
+      summary: Cancel or revoke an in-progress Data Rights Request
+      description: >-
+        This endpoint will instruct the PIP to cancel or revoke a Data
+        Rights Request which is still in a non-terminal state.
+      operationId: revokeRequest
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - request_id
+              properties:
+                request_id:
+                  description: The ID of the request to revoke
+                  type: string
+                  format: uuid
+                reason:
+                  description: MAY contain a user-provided reason for the request to not be processed
+                  type: string
+            
+      responses:
+        '200':
+          $ref: '#/components/responses/ValidDRRStatus'
+# Tangle:1 ends here

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,4 +1,3 @@
-# [[file:../../org/data_rights_interface_protocol.org::*Tangle][Tangle:1]]
 openapi: 3.0.0
 info:
   version: 0.4
@@ -248,4 +247,3 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/ValidDRRStatus'
-# Tangle:1 ends here


### PR DESCRIPTION
go to https://petstore.swagger.io/ and replace the URL in the Explore box with: 
https://raw.githubusercontent.com/rrix/data-rights-protocol/main/openapi.yaml

This is the start of an [openapi](https://oai.github.io/Documentation/start-here.html) specification for the DRP protocol's *PIP Interface*. It's being provided here as step 1 in building out conformance testing for version 0.4 of the protocol, and will probably need to be kept in-sync with the existing markdown spec. 

OpenAPI (F.K.A. swagger) is a machine-legible API specification standard that, in the simplest scenarios, can be used to test APIs in the Swagger web UI.

Further work:
- Exploring documenting the status callbacks through https://swagger.io/docs/specification/callbacks/
- [Authentication](https://swagger.io/docs/specification/authentication/) (including OIDC support!) and feed that back in to the markdown spec

Limitations:
- there's no way to express parameter dependencies https://swagger.io/docs/specification/describing-parameters/#dependencies and so no way to express the specific set of allowable states in DataRequestStatus
- the payload of the identity token can't be expressed or created in the Swagger UI, it'd have to be constructed out of band, it's an opaque string (ping OAI/OpenAPI-Specification#1971) so this makes it un-ideal for test-case generation on its own.