### PR TITLE
add fields to encode "expected by" and express time extensions

### DIFF
--- a/data-rights-protocol.md
+++ b/data-rights-protocol.md
@@ -184,12 +184,12 @@ This table shows valid states for Data Rights Requests, along with the criteria 
 | in_progress | need_user_verification | CB doesn't have sufficient ID verification                          | user_verification_url, expires_at            |        |
 | fulfilled   |                        | CB has finished data rights request process                         | results_url, expires_at                      | x      |
 | revoked     |                        | user has explicitly actioned to revoke the request                  |                                              | x      |
-| denied      | suspected_fraud        | CB or PIP believes this request was made fraudulently               |                                              | x      |
-| denied      | insuf_verification     | the [in_progress, need_user_verification] stage failed or timed out |                                              | x      |
-| denied      | no_match               | CB could not match user identity to data subject                    |                                              | x      |
-| denied      | claim_not_covered      | user requesting data not covered under legal bases[XXX]             |                                              | x      |
-| denied      | outside_jurisdiction   | user requesting data under bases they are not covered by[XXX]       |                                              | x      |
-| denied      | other                  | some other unspecified failure state reached                        | details?                                     | x      |
+| denied      | suspected_fraud        | CB or PIP believes this request was made fraudulently               | processing_details                           | x      |
+| denied      | insuf_verification     | the [in_progress, need_user_verification] stage failed or timed out | processing_details                           | x      |
+| denied      | no_match               | CB could not match user identity to data subject                    | processing_details                           | x      |
+| denied      | claim_not_covered      | user requesting data not covered under legal bases[XXX]             | processing_details                           | x      |
+| denied      | outside_jurisdiction   | user requesting data under bases they are not covered by[XXX]       | processing_details                           | x      |
+| denied      | other                  | some other unspecified failure state reached                        | processing_details                           | x      |
 | expired     |                        | the time is currently after the `expires_at` in the request.        |                                              | x      |
 
 [XXX] in the case of claim_not_covered, this may be about asking for categories of data which Covered Businesses are not required to present to the User. in the case of outside_jurisdiction, this may be because the business is not honoring CCPA requests for non-California residents and there is no other basis on which to honor the request.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -120,6 +120,10 @@ components:
           format: uuid
         received_at:
           type: date-time
+        expected_by:
+          type: date-time
+        processing_details:
+          type: string
         results_url:
           type: string
           format: uri


### PR DESCRIPTION
resolves #37 

This is a fairly general model that provides PIPs/CBs the ability to:
- set a "best effort" expectation on request acknowledgement. This can
  or should be set to the legal regime's timelines if there is no
  estimate.
- express to End User that a request is going to take longer than the
  times originally expected or prescribed
- there is a general messaging field called `processing_details` which
  will make it feasible for AAs to show a simple status message
  provided by PIP/CB to extend the general state/reason fields to
  provide a reason for an extension. This could be useful in terminal
  states as well, and follows on an implicit point which already
  existed in the specification

I believe this approach is quite flexible and applicable to many data
regimes rather than encoding specific California behaviors.