### PR TITLE
add certification repository as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cert"]
+	path = cert
+	url = https://github.com/consumer-reports-digital-lab/data-rights-protocol-cert/

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   title: Data Rights Protocol - PIP Interface
 
 servers:
-  url: http://localhost:9000/drp
+- url: http://localhost:9000/drp
 
 components:
   schemas:


### PR DESCRIPTION
the certification test wants the DRP openapi.yaml to be available and this layout ensures that this is consistent and that implementers will have access to the specification alongside any other development tools.