### PR TITLE
0.7 libsodium swapover

### DIFF
--- a/data-rights-protocol.md
+++ b/data-rights-protocol.md
@@ -409,13 +409,14 @@ When applying changes to Data Rights Requests in this fashion, the Privacy Infra
 
 ## 4.0 Protocol Roadmap
 
-In its current implementation, DRP should not be used to process data of Users who are not involved in the implementers group. This protocol is undergoing significant technical design changes, security evaluation, and implementation work, which should preclude the transfer of arbitrary Users' data rights.
+In its current implementation, DRP should not be used to process data of Users who are not involved in the implementers group or implemented by organizations not in the implementers group. This protocol is undergoing significant technical design changes, security evaluation, and implementation work, which should preclude the transfer of arbitrary Users' data rights.
 
 In steps:
 
-- Moving to signed data rights requests from the Authorized Agents
-- Moving from JWT to libsodium for singing requests
+- [x] Moving to signed data rights requests from the Authorized Agents
+- [x] Moving from JWT to libsodium for singing requests
 - Developing a directory service for Authorized Agents to discover businesses participating in a Data Rights Network, and a directory service for Covered Businesses to resolve message signatures to specific Authorized Agents
+- Developing system rules and legal agreements for implementers.
 
 ## Specification Change Log
 


### PR DESCRIPTION
Protocol Changes from 0.6 to 0.7:

- Restructure API to be more REST-like
- Move from JWT to NaCl/libsodium/Ed25519 signatures. Fixes #54.
- Renaming security claims from JWT short codes to more expressive identifiers. (implementer feedback)
- Add `POST /key-exchange` endpoint to provide mechanism for generating pair-wise API Authorization/routing tokens. Fixes #58.
- Specify timestamps as ISO-8601 instead of RFC-3339. Fixes #61.
- Re-draft API Authentication and Security Guidance sections in line with libsodium, etc.
